### PR TITLE
Change default

### DIFF
--- a/api2.php
+++ b/api2.php
@@ -48,7 +48,7 @@ if (isset($_SERVER['MAGE_IS_DEVELOPER_MODE'])) {
 
 Mage::$headersSentThrowsException = false;
 
-$mageRunCode = isset($_SERVER['MAGE_RUN_CODE']) ? $_SERVER['MAGE_RUN_CODE'] : 'admin';
+$mageRunCode = isset($_SERVER['MAGE_RUN_CODE']) ? $_SERVER['MAGE_RUN_CODE'] : '';
 $mageRunType = isset($_SERVER['MAGE_RUN_TYPE']) ? $_SERVER['MAGE_RUN_TYPE'] : 'store';
 Mage::init($mageRunCode, $mageRunType);
 


### PR DESCRIPTION
In `index.php` this defaults to `''` instead of `'admin'`. That's why if no env vars are set Magento will select the default store in the default website.

If we set this to `admin` here, then the REST API will only work if the env vars are actually set to the correct store, but it will never auto-select the default store like the regular website will do.

@Lee: Will changing this have any side effect?
